### PR TITLE
Fixing compilation problems when using esp8266

### DIFF
--- a/src/Ucglib.cpp
+++ b/src/Ucglib.cpp
@@ -771,7 +771,7 @@ void Ucglib3Wire9bitHWSPI::begin(uint8_t is_transparent)
 /* 8 Bit Parallel */
 
 
-#if defined(__PIC32MX) || defined(__arm__)
+#if defined(__PIC32MX) || defined(__arm__) || defined(ESP8266)
 /* CHIPKIT PIC32 */
 static volatile uint32_t *u8g_data_port[9];
 static uint32_t u8g_data_mask[9];


### PR DESCRIPTION
Your lib is great. I'm moving an small project away from ATMEL CPU's so I needed to make Ucglib to work in this new environment.

Speed isn't great and some examples trigger ESP8266 watchdog (too much time inside only one loop() iteration) but it's working nice for me.

:)