### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=True color TFT and OLED library. Supported display controller: ST7735, 
 paragraph=Features: 18 Bit color depth, many fonts.
 category=Display
 url=https://github.com/olikraus/ucglib
-architectures=all
+architectures=*


### PR DESCRIPTION
As stated in the [Arduino Library Specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification):
>use “*” to match all architectures

Setting the value of `architectures` to `all` causes the included example sketches to not appear in the **File > Examples** menu and the warning:
```
WARNING: library Ucglib_Arduino-master claims to run on [all] architecture(s) and may be incompatible with your current board which runs on [avr] architecture(s).
```
is shown during compilation.